### PR TITLE
Potential fix for code scanning alert no. 2: Potentially unsafe quoting

### DIFF
--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -543,8 +543,7 @@ func (tvc *decimal128Container) SetValueArray(colData arrow.ArrayData) error {
 
 func marshal(val any) ([]byte, error) {
 	if t, ok := val.(time.Time); ok {
-		s := "\"" + t.String() + "\""
-		return []byte(s), nil
+		return json.Marshal(t.String())
 	}
 	vb, err := json.Marshal(val)
 	return vb, err


### PR DESCRIPTION
Potential fix for [https://github.com/cloudquery/databricks-sql-go/security/code-scanning/2](https://github.com/cloudquery/databricks-sql-go/security/code-scanning/2)

To fix the problem in `internal/rows/arrowbased/columnValues.go`, we must ensure that when constructing a quoted string literal containing the output of `t.String()`, any embedded quotes or backslashes are escaped appropriately to avoid breaking the surrounding string. The best practice in Go, as discussed in the background, is to use `json.Marshal()` to quote and escape the value, since it produces a properly-quoted and escaped JSON string.

So, in the function `marshal(val any) ([]byte, error)`, instead of manually concatenating quotes around `t.String()`, we should serialize it using `json.Marshal(t.String())`. This will add double quotes and escape any embedded characters according to JSON rules. Change line 546 from `s := "\"" + t.String() + "\""`, to use `json.Marshal(t.String())`, returning its bytes.

No additional imports are required since `json` is already imported.  
Change only the code within the `marshal` function where a `time.Time` is detected. No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
