### PR TITLE
Potential fix for code scanning alert no. 1: Potentially unsafe quoting

### DIFF
--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -297,11 +297,12 @@ func (mvc *mapValueContainer) Value(i int) (any, error) {
 				b = string(vb)
 			}
 
-			if !strings.HasPrefix(string(key), "\"") {
-				r = r + "\"" + string(key) + "\":"
-			} else {
-				r = r + string(key) + ":"
+			// Always JSON-encode the key to ensure proper quoting/escaping
+			encodedKey, err := json.Marshal(k)
+			if err != nil {
+				return nil, err
 			}
+			r = r + string(encodedKey) + ":"
 
 			r = r + b
 			if i < len-1 {

--- a/internal/rows/arrowbased/columnValues.go
+++ b/internal/rows/arrowbased/columnValues.go
@@ -2,7 +2,6 @@ package arrowbased
 
 import (
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"


### PR DESCRIPTION
Potential fix for [https://github.com/cloudquery/databricks-sql-go/security/code-scanning/1](https://github.com/cloudquery/databricks-sql-go/security/code-scanning/1)

**General Approach:**  
To robustly construct valid JSON objects from untrusted keys and values, avoid building string representations by hand. Instead, use the `encoding/json` package to do the actual encoding (which always takes care of correct escaping and quoting), or — if hand-building is absolutely necessary due to performance or low-level requirements — make sure to JSON-escape and quote the key *using standard library APIs* such as `json.Marshal`.

**Detailed Fix:**  
On line 301, instead of manually enclosing the key in double quotes (and trying to check if it's already quoted), we should always encode the key using `json.Marshal(k)` (not `marshal(k)`, which encodes with custom logic) so that we get double-quoted, escaped key strings. This guarantees that, no matter what data is in `k`, the result will be valid JSON string key syntax.  
- Replace the logic starting at line 300–303: Remove the custom prefix check and always encode keys with `json.Marshal`.
- For simplicity, within the existing context (which seems to gather up a string representation with own formatting), let’s use `json.Marshal(k)` to produce the key and insert it as-is.
- If `marshal(k)` is needed because `k` could be other types (like numbers or objects), and this must match a previous design, be extra careful about *not* stripping or adding redundant quotes. But, for JSON object keys, only strings (or types convertible to strings) are valid, so coercion via `json.Marshal` is safest.
- Update relevant error handling accordingly.

**Affected lines:**  
- In file `internal/rows/arrowbased/columnValues.go`, replace lines 300–303 with logic that always uses `json.Marshal(k)` for the object key and inserts the result directly, followed by a colon.
- This may require updating the usage of `key` in context, possibly moving `k` from before, or using `key`, but marshaling it again as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
